### PR TITLE
Package: 도커컴포트 작성 및 도커 사용 스크립트 작성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+.env
+*.md
+dist/ 
+node_modules/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1
+FROM node:18-alpine As development
+
+USER node
+
+WORKDIR /app
+
+COPY --chown=node:node . .
+
+RUN npm ci
+
+# Stage 2
+FROM node:18-alpine As build
+
+USER node
+
+WORKDIR /app
+
+COPY --chown=node:node . .
+
+COPY --chown=node:node --from=development /app/node_modules ./node_modules
+
+RUN npm run build
+
+RUN npm ci --only=production
+
+# Stage 3
+FROM node:18-alpine As production
+
+WORKDIR /app
+
+COPY --chown=node:node --from=build /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/dist ./dist
+COPY --chown=node:node ./.env .
+
+CMD [ "node", "dist/main.js" ]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Docker
+
+```bash
+# docker-compose 실행(node, postgres, redis, pgadmin)
+$ npm run docker-compose
+
+# docker production image build
+$ npm run deploy:build
+
+# docker production image deploy
+$ npm run deploy:push
+```
+
 ## Installation
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  app:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      target: development
+    env_file:
+      - .env
+    networks:
+      - app-network
+    volumes:
+      - ./src:/app/src
+    ports:
+      - 3000:3000
+    command: npm run start:dev
+    depends_on:
+      - redis
+      - db
+
+  redis:
+    image: redis:7
+    container_name: redis
+    networks:
+      - app-network
+    volumes:
+      - redis-volume:/data
+
+  db:
+    image: postgres:16
+    container_name: db
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    networks:
+      - app-network
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
+
+  dbadmin:
+    image: dpage/pgadmin4:7
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+    networks:
+      - app-network
+    ports:
+      - '5050:80'
+    depends_on:
+      - db
+
+networks:
+  app-network:
+
+volumes:
+  redis-volume:
+  postgres-volume:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "deploy:build": "docker build . -t izone00/42transendence-backend",
+    "deploy:push": "docker push izone00/42transendence-backend",
+    "docker-compose": "docker-compose up",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
script명령어는 세개 작성했습니다. 개발시에는 1번만 쓰면됩니다. readme에도 있으니 참고하세요

1. npm run docker-compose: (개발용)
   - postgre, redis, pgadmin, nestjs 4개 컨테이너 실행
   - localhost:3000에 nestjs서버, localhost:5050에 pgadmin서버 열림
   - npm run start:dev와 거의 똑같은 서버입니다(코드 변경 가능)
   - 일단 node서버도 여는걸로 작성했는데 너무 느리면 db서버만 여는걸로 다시 만들겠습니다.
   
2. npm run deploy:build
   - aws서버에 올릴 도커 이미지를 빌드
 
3. npm run deploy:push
   - 도커허브에 이미지를 푸쉬하는 명령어입니다.
   - aws에 올릴때 쓸려고 했지만 필요없는거 같아 고민중


이해 안가거나 궁금한거 있으시면 물어봐주세요!