### PR TITLE
Fix: signIn핸들러 쿼리 매개변수 받도록 수정, 그 외 오류 몇 개 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,20 +1,20 @@
 import { Controller, Get, Query, Res, Req, Post, Body, UnauthorizedException } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
-import { UsersService } from 'src/users/users.service';
 import { CreateUserDto } from 'src/users/dto/create-user.dto';
+import { UsersService } from 'src/users/users.service';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private authService: AuthService,
     private usersService: UsersService,
-  ) {}
-
+    ) {}
+    
   @Get('sign-in')
-  signIn(@Res() res: Response) {
+  signIn(@Res() res: Response, @Query('callback_uri') callbackUri: string) {
     const state = this.authService.generateRandomString(16);
-    res.status(200).send({ data: this.authService.getRedirectUrl(state) });
+    res.status(200).send({ data: this.authService.getRedirectUrl(state, callbackUri) });
   }
 
   @Get('user-redirect')

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function bootstrap() {
   app.use(cookieParser(), sessionMiddleware(configService));
 
   app.enableCors({
-    origin: 'http://localhost:3000', // 요청을 보내는 클라이언트의 주소를 명시
+    origin: ['http://localhost:3000', 'https://develop.d35lpok7005dz1.amplifyapp.com'], // 요청을 보내는 클라이언트의 주소를 명시
     credentials: true,
   });
   // DB튜플 추가

--- a/src/test.service.ts
+++ b/src/test.service.ts
@@ -5,7 +5,6 @@ import { UsersService } from './users/users.service';
 import { User } from './users/user.entity';
 import { UserRelationStatusEnum } from './user-relation/enums/user-relation-status.enum';
 import { UserRelation } from './user-relation/user-relation.entity';
-import { UserRelationService } from './user-relation/user-relation.service';
 import { CreateUserRelationDto } from './user-relation/dtos/create-user-relation.dto';
 
 @Injectable()
@@ -16,7 +15,6 @@ export class TestService {
     private readonly userRepository: Repository<User>,
     @InjectRepository(UserRelation)
     private readonly userRelationRepository: Repository<UserRelation>,
-    private readonly userRelationService: UserRelationService,
   ) {}
 
   async addUser(): Promise<void> {


### PR DESCRIPTION
### 수정 사항

1. signIn핸들러에서 쿼리 매개변수로 callback_uri를 받도록 수정하였습니다.
``` typescript
@Get('sign-in')
  signIn(@Res() res: Response, @Query('callback_uri') callbackUri: string) {
    const state = this.authService.generateRandomString(16);
    res.status(200).send({ data: this.authService.getRedirectUrl(state, callbackUri) });
  }
```
2. authService의 joinUser 메서드 오류, loginUser메서드에서 set->hset으로 오타 수정하였습니다.