### PR TITLE
내 정보조회API 오류 해결 및 기타 버그 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,13 +28,22 @@ export class AuthController {
   @UseGuards(AuthGuard)
   @Post('logout')
   async logout(@Req() req: Request, @Res() res: Response): Promise<void> {
-    req.session.destroy((err) => {
-      if (err) {
-        throw new InternalServerErrorException();
-      }
-      res.clearCookie('access_token');
-    });
-    res.send('로그아웃 완료');
+    try {
+      await new Promise((resolve, reject) => {
+        req.session.destroy((err) => {
+          if (err) {
+            reject(new InternalServerErrorException('session id detroy error'));
+          } else {
+            res.clearCookie('session-cookie');
+            res.send('로그아웃 성공');
+            resolve(undefined);
+          }
+        });
+      });
+    } catch (err) {
+      console.log(`LOGOUT ERR: ${err}`);
+      throw err;
+    }
     // const sessionKey = `user:${user.id}`;
     // if (await redisClient.exists(sessionKey)) {
     //   await redisClient.hdel(sessionKey, 'email');

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,11 +33,10 @@ export class AuthController {
         req.session.destroy((err) => {
           if (err) {
             reject(new InternalServerErrorException('session id detroy error'));
-          } else {
-            res.clearCookie('session-cookie');
-            res.send('로그아웃 성공');
-            resolve(undefined);
           }
+          res.clearCookie('session-cookie');
+          res.send('로그아웃 성공');
+          resolve(undefined);
         });
       });
     } catch (err) {

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -16,9 +16,11 @@ export class AuthGuard implements CanActivate {
         throw new UnauthorizedException('유효하지 않은 사용자입니다.');
       }
       request.user = user;
+      console.log('authGuard 작동 종료');
       return true;
     }
     console.log('***session 찾기 실패!***');
+    console.log('authGuard 작동 종료');
     throw new UnauthorizedException('로그인이 필요합니다.');
   }
 }

--- a/src/auth/user.decorator.ts
+++ b/src/auth/user.decorator.ts
@@ -1,9 +1,12 @@
 import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 
-export const GetUser = createParamDecorator((ctx: ExecutionContext) => {
+export const GetUser = createParamDecorator((_, ctx: ExecutionContext) => {
+  console.log('GetUser() 시작');
   const request = ctx.switchToHttp().getRequest();
   if (!request.user) {
+    console.log('GetUser() 유효하지 않은 유저');
     throw new UnauthorizedException('유효하지 않은 유저입니다.');
   }
+  console.log('GetUSer() 종료');
   return request.user;
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -28,9 +28,9 @@ export class UsersController {
     return userDtos;
   }
 
-  @Get(':user_id')
-  getUserDetails(@Param('user_id', UserByIdPipe) user: User): ShowUserDetailsDto {
-    const userDto = new ShowUserDetailsDto();
+  @Get('me')
+  getUserInfomation(@GetUser() user: User): ShowUserInforamtionDto {
+    const userDto = new ShowUserInforamtionDto();
     userDto.avatar = user.avatar;
     userDto.bio = user.bio;
     userDto.email = user.email;
@@ -39,9 +39,9 @@ export class UsersController {
     return userDto;
   }
 
-  @Get('me')
-  getUserInfomation(@GetUser() user: User): ShowUserInforamtionDto {
-    const userDto = new ShowUserInforamtionDto();
+  @Get(':user_id')
+  getUserDetails(@Param('user_id', UserByIdPipe) user: User): ShowUserDetailsDto {
+    const userDto = new ShowUserDetailsDto();
     userDto.avatar = user.avatar;
     userDto.bio = user.bio;
     userDto.email = user.email;


### PR DESCRIPTION
### 문제 상황:

GET ('users/me') API가 서버 내부 오류로 인해 500 응답을 반환하는 문제가 발생했습니다.

### 원인 분석:

1. 라우터 충돌:` GET( 'users/me')`와` GET('user/{id}')` 엔드포인트 간의 라우팅 충돌이 있었으며, 이로 인해 서버가 오류 응답을 반환하였습니다.
2. 데코레이터 오류: 로그인된 사용자 객체를 반환하는 `GetUser()` 커스텀 데코레이터가 올바르게 작동하지 않고 있었습니다.

### 해결 방안:

1. 라우터 충돌 해결: 충돌을 일으키는 다른 핸들러보다 `GET ('users/me') `핸들러를 코드 상위에 배치하여 라우팅 충돌 문제를 해결하였습니다.
2. 데코레이터 수정: `createParamDecorator` 함수에서` data` 매개변수를 사용하지 않으나 이를 명시하기 위해 _ (언더스코어)를 매개변수에 추가하여 문제를 해결하였습니다.

### 해결된 모습

![image](https://github.com/ft-transcendence-seoul/backend/assets/95565246/3eee3660-1520-4bcb-811d-4f2aa5b4d532)
![image](https://github.com/ft-transcendence-seoul/backend/assets/95565246/0fa742af-c30d-499e-ae26-cc1dc1a930e5)



### 추가 버그 수정:

로그아웃 핸들러에서의 동기 처리 문제로 인한 오류 발생 가능성을 확인하고, 프로미스를 사용하여 동기 처리를 확실히 함으로써 이를 해결하였습니다. 정확한 오류 원인은 아직 파악되지 않았으나, 수정된 코드를 통해 문제가 발생하지 않을 것으로 예상됩니다.

### 안내 사항
로그인 한 상태에서 제가 담당한 API 테스트를 해보고 있는데, 현재로서는 특정 멤버 정보 조회, 내 정보 수정, 친구 정보 전체 조회, 로그아웃, 로그인, 내 정보 조회 API 들은 오류 없이 정상 동작하는 것 같습니다.
나머지API에 대해서는 아직 테스트가 필요해서 오류가 발생할 수 있습니다.  이는 내일 저녁에 테스트해볼예정입니다.

