### PR TITLE
Feature: 유저가 접속한 채널과 각 채널의 역할 조회, ChannelByIdPipe, UserByIdPipe로 예외 처리 등등

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -1,5 +1,5 @@
 import { ChannelByIdPipe } from './../pipes/ChannelById.Pipe';
-import { Body, Controller, Delete, Get, Param,  Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
 import { ChannelsService } from './channels.service';
 import { GetUser } from 'src/auth/user.decorator';
 import { User } from 'src/users/user.entity';
@@ -40,14 +40,14 @@ export class ChannelsController {
   }
 
   @Delete(':channel_id')
-  exitChannel(@GetUser() user: User, @Param('channel_id', ChannelByIdPipe) channel: Channel): Promise<void> {
-    return this.channelService.exitChannel(user, channel.id);
+  exitChannel(@GetUser() user: User, @Param('channel_id', ParseIntPipe) channelId: number): Promise<void> {
+    return this.channelService.exitChannel(user, channelId);
   }
 
   @Get(':channel_id/ban')
   @UseGuards(AdminGuard)
-  getAllChannelBannedUsers(@Param('channel_id', ChannelByIdPipe) channel: Channel): Promise<User[]> {
-    return this.channelService.findAllChannelBannedUsers(channel.id);
+  getAllChannelBannedUsers(@Param('channel_id', ParseIntPipe) channelId: number): Promise<User[]> {
+    return this.channelService.findAllChannelBannedUsers(channelId);
   }
 
   @Post(':channel_id/ban/:user_id')
@@ -62,8 +62,11 @@ export class ChannelsController {
 
   @Delete(':channel_id/ban/:user_id')
   @UseGuards(AdminGuard)
-  cancelBannedUser(@Param('channel_id', ChannelByIdPipe) channel: Channel, @Param('user_id', UserByIdPipe) user: User): Promise<void> {
-    return this.channelService.cancelBannedUser(channel.id, user.id);
+  cancelBannedUser(
+    @Param('channel_id', ParseIntPipe) channelId: number,
+    @Param('user_id', ParseIntPipe) userId: number,
+  ): Promise<void> {
+    return this.channelService.cancelBannedUser(channelId, userId);
   }
 
   @Delete(':channel_id/kick/:user_id')
@@ -78,20 +81,20 @@ export class ChannelsController {
 
   @Put(':channel_id/admin/:user_id/give')
   @UseGuards(OwnerGuard)
-  giveAdmin(@Param('channel_id', ChannelByIdPipe) channel: Channel, @Param('user_id', UserByIdPipe) user: User): Promise<void> {
-    return this.channelService.updateAdmin(channel.id, user.id, { isAdmin: true });
+  giveAdmin(@Param('channel_id', ParseIntPipe) channelId: number, @Param('user_id', ParseIntPipe) userId: number): Promise<void> {
+    return this.channelService.updateAdmin(channelId, userId, { isAdmin: true });
   }
 
   @Put(':channel_id/admin/:user_id/deprive')
   @UseGuards(OwnerGuard)
-  depriveAdmin(@Param('channel_id', ChannelByIdPipe) channel: Channel, @Param('user_id', UserByIdPipe) user: User): Promise<void> {
-    return this.channelService.updateAdmin(channel.id, user.id, { isAdmin: false });
+  depriveAdmin(@Param('channel_id', ParseIntPipe) channelId: number, @Param('user_id', ParseIntPipe) userId: number): Promise<void> {
+    return this.channelService.updateAdmin(channelId, userId, { isAdmin: false });
   }
 
   @Put(':channel_id/owner/:user_id')
   @UseGuards(OwnerGuard)
-  changeOwner(@GetUser() owner: User, @Param('channel_id', ChannelByIdPipe) channel: Channel, @Param('user_id', UserByIdPipe) successorId: User): Promise<void> {
-    return this.channelService.changeOwner(channel.id, owner.id, successorId.id);
+  changeOwner(@GetUser() owner: User, @Param('channel_id', ParseIntPipe) channelId: number, @Param('user_id', ParseIntPipe) successorId: number): Promise<void> {
+    return this.channelService.changeOwner(channelId, owner.id, successorId);
   }
 
   @Post(':channel_id/invite/:user_id')

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -20,6 +20,11 @@ export class ChannelsController {
     return this.channelService.createChannel(user, channelDto);
   }
 
+  @Get('me')
+  getChannelsByUser(@GetUser() user: User): Promise<any[]> {
+    return this.channelService.findChannelsByUser(user.id);
+  }
+
   @Put(':channel_id')
   @UseGuards(OwnerGuard)
   updateChannel(
@@ -52,7 +57,7 @@ export class ChannelsController {
 
   @Post(':channel_id/ban/:user_id')
   @UseGuards(AdminGuard)
-  async banUser(
+  banUser(
     @Param('channel_id', ChannelByIdPipe) channel: Channel,
     @Param('user_id', UserByIdPipe) userToBan: User,
     @GetUser() actingUser: User
@@ -71,7 +76,7 @@ export class ChannelsController {
 
   @Delete(':channel_id/kick/:user_id')
   @UseGuards(AdminGuard)
-  async kickUser(
+  kickUser(
     @Param('channel_id', ChannelByIdPipe) channel: Channel,
     @Param('user_id', UserByIdPipe) userToKick: User,
     @GetUser() actingUser: User
@@ -128,11 +133,6 @@ export class ChannelsController {
     @Body() body: { providedPassword: string },
   ): Promise<void> {
     return this.channelService.join(user, channel, body.providedPassword);
-  }
-
-  @Get('me')
-  async getChannelsByUser(@GetUser() user: User): Promise<any[]> {
-    return this.channelService.findChannelsByUser(user);
   }
 
 

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -127,8 +127,8 @@ export class ChannelsController {
     return this.channelService.join(user, channel, body.providedPassword);
   }
 
-  @Get('user/:user_id')
-    async getChannelsByUser(@Param('user_id', UserByIdPipe) user: User): Promise<any[]> {
+  @Get('me')
+  async getChannelsByUser(@GetUser() user: User): Promise<any[]> {
     return this.channelService.findChannelsByUser(user);
   }
 

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -35,8 +35,8 @@ export class ChannelsController {
   }
 
   @Get(':channel_id')
-  getOneChannel(@Param('channel_id', ChannelByIdPipe) channel: Channel): Promise<Channel> {
-    return this.channelService.findOneChannel(channel.id);
+  getOneChannelWithUsers(@Param('channel_id', ParseIntPipe) channelId: number): Promise<Channel> {
+    return this.channelService.findOneChannelWithUsers(channelId);
   }
 
   @Get()
@@ -58,11 +58,11 @@ export class ChannelsController {
   @Post(':channel_id/ban/:user_id')
   @UseGuards(AdminGuard)
   banUser(
-    @Param('channel_id', ChannelByIdPipe) channel: Channel,
+    @Param('channel_id', ParseIntPipe) channelId: number,
     @Param('user_id', UserByIdPipe) userToBan: User,
     @GetUser() actingUser: User
   ): Promise<void> {
-    return this.channelService.banUser(channel.id, userToBan.id, actingUser.id);
+    return this.channelService.banUser(channelId, userToBan.id, actingUser.id);
   }
 
   @Delete(':channel_id/ban/:user_id')
@@ -77,11 +77,11 @@ export class ChannelsController {
   @Delete(':channel_id/kick/:user_id')
   @UseGuards(AdminGuard)
   kickUser(
-    @Param('channel_id', ChannelByIdPipe) channel: Channel,
+    @Param('channel_id', ParseIntPipe) channelId: number,
     @Param('user_id', UserByIdPipe) userToKick: User,
     @GetUser() actingUser: User
   ) {
-    return this.channelService.kickUser(channel.id, userToKick.id, actingUser.id);
+    return this.channelService.kickUser(channelId, userToKick.id, actingUser.id);
   }
 
   @Put(':channel_id/admin/:user_id/give')

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -425,9 +425,9 @@ export class ChannelsService {
     });
   }
 
-  async findChannelsByUser(user: User): Promise<any[]> {
+  async findChannelsByUser(userId: number): Promise<any[]> {
     const channelRelations = await this.channelRelationRepository.find({
-      where: { user: { id: user.id } },
+      where: { user: { id: userId } },
       relations: ['channel'],
     });
 

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -89,6 +89,10 @@ export class ChannelsService {
         relations: ['channelRelations', 'channelRelations.user'],
     });
 
+    if (!channelWithUsers) {
+      throw new NotFoundException('채널을 찾을 수 없습니다!');
+    }
+
     return channelWithUsers;
 }
 

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -83,6 +83,15 @@ export class ChannelsService {
     return channel;
   }
 
+  async findOneChannelWithUsers(channelId: number): Promise<Channel> {
+    const channelWithUsers = await this.channelRepository.findOne({
+        where: { id: channelId },
+        relations: ['channelRelations', 'channelRelations.user'],
+    });
+
+    return channelWithUsers;
+}
+
   async exitChannel(user: User, channelId: number): Promise<void> {
     let ifTranferNeeded = false;
     const channelRelation = await this.channelRelationRepository.findOne({

--- a/src/channels/entities/channel-relation.entity.ts
+++ b/src/channels/entities/channel-relation.entity.ts
@@ -19,14 +19,14 @@ export class ChannelRelation {
   @CreateDateColumn()
   createdAt: Date;
 
-  @Column({ default: false })
-  isMuted: boolean;
+  // @Column({ default: false })
+  // isMuted: boolean;
 
-  @Column({ default: 5 })
-  mutedTime: number;
+  // @Column({ default: 5 })
+  // mutedTime: number;
 
-  @CreateDateColumn()
-  muteCreatedAt: Date;
+  // @CreateDateColumn()
+  // muteCreatedAt: Date;
 
   @ManyToOne(() => User, (user) => user.channelRelations, {
     onDelete: 'CASCADE',


### PR DESCRIPTION
Feature: 유저가 접속한 채널과 각 채널의 역할 조회
Refactor: ChannelByIdPipe, UserByIdPipe로 모두 교체 후 예외처리 완료
Fix: 관리자는 유저만 ban 가능하게 구현
Fix: 유저가 초대를 수락하면 채널에 자동 입장시키기, 에러 메시지 구체화

1. 프론트에서 재로그인 시에 확인이 필요한 api 구현(유저가 접속한 채널과 각 채널의 역할 조회)
2. ParseIntPipe을 모두 custom pipe로 교체하여 예외처리 완료
3. ban 기능에서 관리자끼리의 ban 방지(kick 포함)
4. 유저가 초대를 수락하면 자동으로 채널 멤버가 될 수 있게 개선
5. 직관적인 변수로 변경 및 에러 메시지 구체화

모두 정상 작동하는 것을 테스트한 결과로 pr 올립니다.