### PR TITLE
Feature: mute 기능 추가

### DIFF
--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -135,6 +135,16 @@ export class ChannelsController {
     return this.channelService.join(user, channel, body.providedPassword);
   }
 
+  @Post(':channel_id/mute/:user_id')
+  @UseGuards(AdminGuard)
+  muteUser(
+    @Param('channel_id', ParseIntPipe) channelId: number,
+    @Param('user_id', UserByIdPipe) userToMute: User,
+    @GetUser() actingUser: User
+  ): Promise<void> {
+      return this.channelService.muteUser(channelId, userToMute.id, actingUser.id);
+  }
+
 
 }
 

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -106,8 +106,9 @@ export class ChannelsController {
   inviteUser(
     @Param('channel_id', ChannelByIdPipe) channel: Channel,
     @Param('user_id', UserByIdPipe) invitedUser: User,
-    ): Promise<ChannelInvitation> {
-    return this.channelService.inviteUser(channel, invitedUser);
+    @GetUser() actingUser: User
+  ): Promise<ChannelInvitation> {
+    return this.channelService.inviteUser(channel, invitedUser, actingUser);
   }
 
   @Post(':channel_id/accept-invite')

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -290,7 +290,19 @@ export class ChannelsService {
     this.channelRelationRepository.save([currentOwnerRelation, successorRelation]);
   }
 
-  async inviteUser(channel: Channel, invitedUser: User): Promise<ChannelInvitation> {
+  async inviteUser(channel: Channel, invitedUser: User, actingUser: User): Promise<ChannelInvitation> {
+    const actingUserRelation = await this.channelRelationRepository.findOne({
+      where: { channel, user: actingUser },
+    });
+
+    if (!actingUserRelation) {
+      throw new ForbiddenException('초대하려는 유저는 채널의 멤버가 아닙니다!');
+    }
+
+    if (invitedUser.id === actingUser.id) {
+      throw new BadRequestException('자신을 채널에 초대할 수 없습니다!');
+   }
+
     if (channel.type !== ChannelType.private) {
       throw new BadRequestException('private 채널에서만 초대가 허용됩니다!');
     }

--- a/src/channels/entities/channel-relation.entity.ts
+++ b/src/channels/entities/channel-relation.entity.ts
@@ -19,9 +19,6 @@ export class ChannelRelation {
   @CreateDateColumn()
   createdAt: Date;
 
-  @Column({ default: false })
-  isMuted: boolean;
-
   @Column({ nullable: true, type: 'timestamp' })
   muteUntil: Date;
 

--- a/src/channels/entities/channel-relation.entity.ts
+++ b/src/channels/entities/channel-relation.entity.ts
@@ -19,14 +19,11 @@ export class ChannelRelation {
   @CreateDateColumn()
   createdAt: Date;
 
-  // @Column({ default: false })
-  // isMuted: boolean;
+  @Column({ default: false })
+  isMuted: boolean;
 
-  // @Column({ default: 5 })
-  // mutedTime: number;
-
-  // @CreateDateColumn()
-  // muteCreatedAt: Date;
+  @Column({ nullable: true, type: 'timestamp' })
+  muteUntil: Date;
 
   @ManyToOne(() => User, (user) => user.channelRelations, {
     onDelete: 'CASCADE',


### PR DESCRIPTION
- setMinutes과 getMinutes 메소드를 활용해서 5분 경과 후 unmute 상태 확인 가능

우진님이 소켓과 연동할 때 들어갈 적절한 소켓 메소드 호출 위치를 주석으로 처리하였고 소켓에서 필요한 메소드는 크게 두 가지로 구성했습니다.

isUserMuted 메소드로 mute, unmute 상태를 체크해서 mute 시 유저들에게 메시지가 전송되지 않게 처리할 수 있으며, 

muteUser 메소드로 isMuted를 true로 설정함과 동시에 소켓을 통해 실시간으로 모든 유저들에게 mute됐다고 알릴 수 있습니다.

또 ban, kick 기능처럼 owner, admin 조건문을 두었고, ban 기능과의 차이는 relation entity에 5분 경과 후인지 알 수 있는 muteUntil이라는 entity가 더해졌고 그 이외에는 ban와 로직이 동일합니다.

부가적인 설명은 issues 참고해주세요.

(+초대 예외 처리 추가)