### PR TITLE
Fix: Get('users/me') API 반환 DTO에 is2FA 필드 추가

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -37,6 +37,7 @@ export class UsersController {
     userDto.email = user.email;
     userDto.ladderPoint = user.ladderPoint;
     userDto.nickname = user.nickname;
+    userDto.is2fa = user.is2fa;
     return userDto;
   }
 


### PR DESCRIPTION
### 수정 사항
내 정보조회를 위한 API (`Get('users/me')`)의 반환 DTO에 is2FA 필드가 누락되어, 추가하였습니다.  수정된 반환 형식은 아래와 같습니다.
```json
{
    "id": 1,
    "avatar": 0,
    "bio": null,
    "email": "user1@example.com",
    "ladderPoint": 0,
    "nickname": "user1",
    "is2fa": false
}
```