### PR TITLE
Feat/#68 중복 로그인 방지 구현

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -26,27 +26,12 @@ export class AuthController {
     private usersService: UsersService,
   ) {}
 
-  // async logout(@Req() req: Request, @Res() res: Response, @GetUser() user: User): Promise<void> {
   @UseGuards(AuthGuard)
   @Post('logout')
   async logout(@Req() req: Request, @Res() res: Response): Promise<void> {
-    await new Promise((resolve, reject) => {
-      req.session.destroy((err) => {
-        if (err) {
-          reject(console.log(`LOGOUT ERR: ${err}`));
-        }
-        res.clearCookie('session-cookie');
-        res.send('로그아웃 성공');
-        resolve(undefined);
-      });
-    });
-    // const sessionKey = `user:${user.id}`;
-    // if (await redisClient.exists(sessionKey)) {
-    //   await redisClient.hdel(sessionKey, 'email');
-    //   res.send('로그아웃 성공');
-    // } else {
-    //   res.send('로그아웃 실패');
-    // }
+    this.authService.removeSession(req);
+    res.clearCookie('session-cookie');
+    res.send('로그아웃 성공');
   }
 
   @Get('sign-in')

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,26 +1,36 @@
 import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { UsersService } from 'src/users/users.service';
 import { User } from 'src/users/user.entity';
+import { RedisService } from 'src/commons/redis-client.service';
+import { RedisField } from 'src/commons/enums/redis.enum';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly redisService: RedisService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    console.log('authGuard 작동 시작');
     if (request?.session.userId) {
-      console.log(`***session 찾기 성공: ${request.session.userId} ***`);
-      const user: User = await this.usersService.findById(request.session.userId);
-      if (!user) {
-        throw new UnauthorizedException('유효하지 않은 사용자입니다.');
+      const userId = request.session.userId;
+      const sessionId = await this.redisService.hget(
+        RedisField.USER_TO_SESSION + userId,
+        RedisField.SESSION_ID,
+      );
+      if (sessionId && sessionId === request.sessionID) {
+        const user: User = await this.usersService.findById(userId);
+        if (!user) {
+          throw new UnauthorizedException('유효하지 않은 사용자입니다.');
+        }
+        request.user = user;
+        return true;
+      } else {
+        throw new UnauthorizedException('소켓이 연결되지 않았습니다.');
       }
-      request.user = user;
-      console.log('authGuard 작동 종료');
-      return true;
+    } else {
+      throw new UnauthorizedException('로그인이 필요합니다.');
     }
-    console.log('***session 찾기 실패!***');
-    console.log('authGuard 작동 종료');
-    throw new UnauthorizedException('로그인이 필요합니다.');
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,9 +4,10 @@ import { AuthService } from './auth.service';
 import { UsersModule } from 'src/users/users.module';
 import { ConfigModule } from '@nestjs/config';
 import { SecureShieldModule } from 'src/secure-shield/secure-shield.module';
+import { CommonsModule } from 'src/commons/commons.module';
 
 @Module({
-  imports: [UsersModule, ConfigModule, SecureShieldModule],
+  imports: [UsersModule, ConfigModule, SecureShieldModule, CommonsModule],
   controllers: [AuthController],
   providers: [AuthService],
   exports: [AuthService],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,6 +8,8 @@ import { UsersService } from 'src/users/users.service';
 import { CreateUserDto } from 'src/users/dtos/create-user.dto';
 import { SecureShieldService } from 'src/secure-shield/secure-shield.service';
 import { TotpDto } from 'src/secure-shield/dtos/totp.dto';
+import { RedisService } from 'src/commons/redis-client.service';
+import { RedisField } from 'src/commons/enums/redis.enum';
 
 @Injectable()
 export class AuthService {
@@ -15,6 +17,7 @@ export class AuthService {
     private configService: ConfigService,
     private usersService: UsersService,
     private secureShieldService: SecureShieldService,
+    private redisService: RedisService,
   ) {}
 
   private readonly AUTHORIZATION_URI = 'https://api.intra.42.fr/oauth/authorize';
@@ -60,11 +63,6 @@ export class AuthService {
 
   async saveSession(req: Request, user: User): Promise<void> {
     if (user) {
-      // const sessionData = await redisClient.hget(`hash:${user.id}`.toString(), 'email');
-      // if (sessionData) {
-      // throw new ConflictException('이미 다른 기기에서 로그인되었습니다.');
-      // }
-      // await redisClient.hset(`user:${user.id}`.toString(), { email: user.email });
       req.session.userId = user.id;
       if (req?.session.userId) {
         console.log(`***express session 저장 성공!: ${req.session.userId} ***`);
@@ -72,6 +70,17 @@ export class AuthService {
     } else {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
+  }
+
+  async removeSession(req: Request) {
+    await new Promise((resolve, reject) => {
+      req.session.destroy((err) => {
+        if (err) {
+          reject(console.log(`LOGOUT ERR: ${err}`));
+        }
+        resolve(undefined);
+      });
+    });
   }
 
   async joinUser(userEmail: string, createUserDto: CreateUserDto): Promise<User> {

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -9,6 +9,7 @@ import { ChannelInvitation } from './entities/channel-invitation.entity';
 import { ChannelGateway } from './channels.gateway';
 import { UserRelationModule } from 'src/user-relation/user-relation.module';
 import { SocketConnectionModule } from 'src/socket-connection/socket-connection.module';
+import { CommonsModule } from 'src/commons/commons.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { SocketConnectionModule } from 'src/socket-connection/socket-connection.
     UsersModule,
     UserRelationModule,
     SocketConnectionModule,
+    CommonsModule,
   ],
   controllers: [ChannelsController],
   providers: [ChannelsService, ChannelGateway],

--- a/src/commons/enums/redis.enum.ts
+++ b/src/commons/enums/redis.enum.ts
@@ -2,4 +2,6 @@ export enum RedisField {
   SOCKET_TO_USER = 'socketToUser',
   USER_TO_SOCKER = 'userToSocket',
   USER_STATUS = 'userStatus',
+  USER_TO_SESSION = 'userToSession:',
+  SESSION_ID = 'sessionId',
 }

--- a/src/commons/enums/redis.enum.ts
+++ b/src/commons/enums/redis.enum.ts
@@ -1,6 +1,6 @@
 export enum RedisField {
   SOCKET_TO_USER = 'socketToUser',
-  USER_TO_SOCKER = 'userToSocket',
+  USER_TO_SOCKET = 'userToSocket',
   USER_STATUS = 'userStatus',
   USER_TO_SESSION = 'userToSession:',
   SESSION_ID = 'sessionId',

--- a/src/commons/redis-client.service.ts
+++ b/src/commons/redis-client.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { Redis } from 'ioredis';
-import { Socket } from 'socket.io';
-import { RedisField } from './enums/redis.enum';
 
 @Injectable()
 export class RedisService {

--- a/src/socket-connection/socket-connection.gateway.ts
+++ b/src/socket-connection/socket-connection.gateway.ts
@@ -62,7 +62,7 @@ export class SocketConnectionGateway {
     );
     await this.redisService.hset(
       USER_ID_PREFIX + userId,
-      RedisField.USER_TO_SOCKER,
+      RedisField.USER_TO_SOCKET,
       clientSocketId,
     );
     await this.redisService.hset(USER_ID_PREFIX + userId, RedisField.USER_STATUS, 'online');
@@ -70,7 +70,7 @@ export class SocketConnectionGateway {
 
   private async removeClientRedis(clientSocketId: string, userId: string | number): Promise<void> {
     await this.redisService.hdel(SOCKET_ID_PREFIX + clientSocketId, RedisField.SOCKET_TO_USER);
-    await this.redisService.hdel(USER_ID_PREFIX + userId, RedisField.USER_TO_SOCKER);
+    await this.redisService.hdel(USER_ID_PREFIX + userId, RedisField.USER_TO_SOCKET);
     await this.redisService.hdel(USER_ID_PREFIX + userId, RedisField.USER_STATUS);
   }
 
@@ -84,7 +84,7 @@ export class SocketConnectionGateway {
   async userToSocket(userId: number): Promise<Socket | null> {
     const socketId = await this.redisService.hget(
       USER_ID_PREFIX + userId,
-      RedisField.USER_TO_SOCKER,
+      RedisField.USER_TO_SOCKET,
     );
     const socket = this.server.sockets.sockets.get(socketId);
     return socket;

--- a/src/user-relation/user-relation.module.ts
+++ b/src/user-relation/user-relation.module.ts
@@ -6,9 +6,10 @@ import { UserRelation } from './user-relation.entity';
 import { User } from 'src/users/user.entity';
 import { UsersModule } from 'src/users/users.module';
 import { UserRelationGateway } from './user-relation.gateway';
+import { CommonsModule } from 'src/commons/commons.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserRelation, User]), UsersModule],
+  imports: [TypeOrmModule.forFeature([UserRelation, User]), UsersModule, CommonsModule],
   controllers: [UserRelationController],
   providers: [UserRelationService, UserRelationGateway],
   exports: [TypeOrmModule, UserRelationService],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,9 +4,10 @@ import { UsersService } from './users.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { SecureShieldModule } from 'src/secure-shield/secure-shield.module';
+import { CommonsModule } from 'src/commons/commons.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), SecureShieldModule],
+  imports: [TypeOrmModule.forFeature([User]), SecureShieldModule, CommonsModule],
   exports: [TypeOrmModule, UsersService],
   providers: [UsersService],
   controllers: [UsersController],


### PR DESCRIPTION
### 추가된 사항
- 자동 로그인과 중복 로그인 방지를 위한 로직 추가
- RedisFieldEnum에 속한 특정 변수 오타 수정

### 로직의  흐름 설명

1. **로그인과 세션 유지**
    - 클라이언트가 로그인하면, 서버는 고유한 **`sessionId`** 를 생성하여 저장합니다.
    - 이 **`sessionId`** 는 클라이언트가 로그아웃하지 않는 한 만료될 때까지 유지됩니다.
    - 이를 통해 클라이언트가 브라우저를 종료하고 나중에 재접속해도 자동으로 로그인 상태가 유지됩니다. 
2. **소켓 연결 및 세션 관리**
    - 클라이언트가 웹에 접속하면, 소켓 연결이 이루어지고, **`userToSession`** 객체가 생성되어 저장됩니다. 이 객체는 사용자의 ID를 키로, **`sessionId`** 를 값으로 가집니다.
    - 클라이언트가 브라우저를 종료하면, 소켓 연결이 끊어지고 **`userToSession`** 객체가 삭제됩니다. 하지만 **`sessionId`** 는 서버에 남아 있습니다.
3. **중복 로그인 방지**
    - 만약 다른 세션에서 같은 ID로 로그인이 시도되면, 기존 로그인된 유저의 소켓 연결이 해제되고, 해당 **`userToSession`** 객체가 삭제됩니다.
    - 새로운 유저에 대해서는 새로운 소켓 연결이 설정되고, 새로운 **`userToSession`** 객체가 생성됩니다.
4. **로그인 필요 API 호출시 추가 검증**
    - 클라이언트가 소켓에 연결되기 전에 인증이 필요한 API를 호출하면, **`AuthGuard`** 가 사용자의 소켓 연결 여부를 확인합니다.
    - 이를 통해 사용자가 현재 세션에서 유효한 **`userToSession`** 을 가지고 있는지 확인하여 중복 로그인을 방지합니다.

### 중복 로그인 방지에 대한 예시 상황1:

- **세션 A에서 로그인** : 사용자 **`spew11`** 이 세션 A에서 로그인하면 **`sessionId: "abc"`** 가 생성되고, **`userToSession`** 객체 **`{ userToSession: spew11, sessionID: "abc"}`** 가 생성됩니다.
- **세션 B에서의 로그인 시도** : 같은 사용자가 세션 B에서 로그인을 시도하면 **`sessionId: "bdf"`** 가 생성되고, 새로운 **`userToSession`** 객체 **`{ userToSession: spew11, sessionID: "bdf"}`** 가 저장됩니다. (이 과정에서 동일한 아이디를 키로 갖는 A의 **`userToSession`** 을 찾아 A의 소켓 연결을 해제하고, A의 **`userToSession`** 역시 삭제합니다.)
- 이 과정을 통해서 중복 로그인이 방지됩니다.

### 중복 로그인 방지에 대한 예시 상황2:

1. **세션 A에서의 로그인과 세션 유지**
    - 사용자 **`spew11`** 이 세션 A에서 로그인합니다. 이 때, **`sessionID: "abc"`** 와 **`{ userToSession: spew11, sessionID: "abc"}`** 객체가 생성됩니다.
    - 세션 A의 브라우저를 종료하면, **`userToSession`** 객체는 서버에서 삭제되지만, **`sessionID: "abc"`** 는 남아 있습니다.
    - 영속 쿠키로 인해 사용자는 브라우저를 종료하고 재접속해도 별도의 로그인 없이 자동으로 로그인 상태가 유지됩니다.
2. **세션 B에서의 로그인 시도**
    - 같은 사용자가 세션 B에서 로그인을 시도하면, 새로운 **`sessionID: "bdf"`** 가 생성됩니다.
    - 소켓 연결이 이루어지고, 새로운 **`{ userToSession: spew11, sessionID: "bdf"}`** 객체가 생성되어 저장됩니다. (이 과정에서 동일한 아이디를 키로 갖는 **`userToSession`** 이 존재하지 않기 때문에 별도의 타 소켓 연결 해제가 발생하지 않습니다.)
3. **중복 로그인 방지**
    - 이 상황에서 세션 A가 다시 접속했는데 소켓 연결이 지연될 경우, 세션 A와 세션 B가 동일한 ID로 동시에 활동할 가능성이 생깁니다.
    - 이를 방지하기 위해, 로그인이 필요한 API를 호출할 때, 소켓이 연결되었는지, 그리고 **`userToSession`** 객체가 올바르게 생성되었는지 확인하는 로직을 AuthGuard에 추가했습니다.

### 요약:

- 이 시스템은 사용자가 브라우저를 종료하고 재접속할 때 자동 로그인을 유지하면서도, 동일한 ID로 다른 세션에서 로그인을 시도할 때 중복 로그인을 방지합니다.
- 소켓 연결 지연이나 다른 세션에서의 로그인 시도로 인해 중복 로그인의 가능성이 생기는 상황에서 추가적인 검증 로직을 통해 이를 방지합니다.

### 안내 사항:
socket단에서의 추가 로직 구현 후에 정상 동작을 테스트해보기 위해서 develop이 아닌 [Feat/#68-중복-로그인-방지-구현-테스트] 브랜치에 병합을 요청합니다.