### PR TITLE
Fix: generateTotpQrCode() 수정 및 generateTotpAuthUrl() 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -119,14 +119,14 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard)
-  @Get('2fa/setup')
+  @Post('2fa/setup')
   async getTotpQrCode(@Res() res: Response, @GetUser() user: User): Promise<void> {
     const qrimgurl = await this.authService.initialize2fa(res, user);
     res.send({ qrimgurl: qrimgurl });
   }
 
   @UseGuards(AuthGuard)
-  @Get('2fa/setup/url')
+  @Post('2fa/setup/url')
   async getTotpAuthUrl(@Res() res: Response, @GetUser() user: User): Promise<void> {
     const otpauthurl = await this.authService.initialize2fa2(res, user);
     res.send({ otpauthurl: otpauthurl });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -119,9 +119,17 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard)
-  @Post('2fa/setup')
-  async getOtpAuthUrl(@Res() res: Response, @GetUser() user: User): Promise<void> {
-    await this.authService.initialize2fa(res, user);
+  @Get('2fa/setup')
+  async getTotpQrCode(@Res() res: Response, @GetUser() user: User): Promise<void> {
+    const qrimgurl = await this.authService.initialize2fa(res, user);
+    res.send({ qrimgurl: qrimgurl });
+  }
+
+  @UseGuards(AuthGuard)
+  @Get('2fa/setup/url')
+  async getTotpAuthUrl(@Res() res: Response, @GetUser() user: User): Promise<void> {
+    const otpauthurl = await this.authService.initialize2fa2(res, user);
+    res.send({ otpauthurl: otpauthurl });
   }
 
   @UseGuards(AuthGuard)

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -82,15 +82,27 @@ export class AuthService {
     return this.usersService.createUser(userEmail, createUserDto);
   }
 
-  async initialize2fa(res: Response, user: User): Promise<void> {
+  async initialize2fa2(res: Response, user: User): Promise<string> {
     if (user.is2fa) {
       throw new BadRequestException('2단계 인증이 이미 활성화 상태입니다.');
     }
     if (!user.otpSecret) {
       await this.usersService.createSecretKey(user);
     }
-    this.secureShieldService.generateTotpQrCode(
-      res,
+    return this.secureShieldService.generateTotpAuthUrl(
+      user.email,
+      this.secureShieldService.decrypt(user.otpSecret),
+    );
+  }
+
+  async initialize2fa(res: Response, user: User): Promise<string> {
+    if (user.is2fa) {
+      throw new BadRequestException('2단계 인증이 이미 활성화 상태입니다.');
+    }
+    if (!user.otpSecret) {
+      await this.usersService.createSecretKey(user);
+    }
+    return this.secureShieldService.generateTotpQrCode(
       user.email,
       this.secureShieldService.decrypt(user.otpSecret),
     );

--- a/src/secure-shield/secure-shield.service.ts
+++ b/src/secure-shield/secure-shield.service.ts
@@ -3,8 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { authenticator } from 'otplib';
 import * as base32 from 'thirty-two';
-import { toFileStream } from 'qrcode';
-import { Response } from 'express';
+import { toDataURL } from 'qrcode';
 
 @Injectable()
 export class SecureShieldService {
@@ -13,9 +12,12 @@ export class SecureShieldService {
   private readonly algorithm = 'aes-256-cbc';
   private readonly serviceName = 'ft_transendence';
 
-  generateTotpQrCode(res: Response, email: string, secretKey: string): void {
-    const otpauthurl = authenticator.keyuri(email, this.serviceName, secretKey);
-    toFileStream(res, otpauthurl);
+  generateTotpAuthUrl(email: string, secretKey: string): string {
+    return authenticator.keyuri(email, this.serviceName, secretKey);
+  }
+
+  generateTotpQrCode(email: string, secretKey: string) {
+    return toDataURL(this.generateTotpAuthUrl(email, secretKey));
   }
 
   generateSecretKey(): string {


### PR DESCRIPTION

### 수정된 내용
1. **API 변경 - Blob 파일에서 Base64 인코딩된 QR 코드 이미지 URL로의 전환**
   - 기존의 `Get('auth/2fa/setup')` API는 blob 파일을 반환했으나, 이제 Base64 인코딩된 QR 코드 이미지 URL을 반환하도록 변경하였습니다.
   - 추가적으로, HTTP 요청 메서드도 기존의 Get에서 Post로 변경하였습니다. 현재 엔드포인트는 `Post('auth/2fa/setup')`입니다.
   - 반환되는 JSON 형식은 다음과 같습니다:
     ```json
     {
         "qrimgurl": "data:image/png;base64,iVBO ..... Aw7SURB5ErkJggg=="
     }
     ```
   - 반환된 URL은 HTML 이미지 태그에 직접 삽입하여 이미지를 표시할 수 있습니다:
     ```html
     <!DOCTYPE html>
     <html>
     <head>
         <title>Base64 이미지 표시</title>
     </head>
     <body>
         <img src="data:image/png;base64,iVBO ..... Aw7SURB5ErkJggg=="></img>
     </body>
     </html>
     ```
   - 위와 같은 방법으로 QR 코드 이미지가 웹 페이지에 표시됩니다. 예시 이미지는 [여기](https://github.com/ft-transcendence-seoul/backend/assets/95565246/841aed6a-b8d1-429d-b103-08b92a6198fd)에서 확인할 수 있습니다.

2. **기존에 있던  API 다시 추가 - OTP URL 반환**
   - QR 코드 이미지를 생성하는 라이브러리를 필수로 사용해야하는 OTP URL을 반환하는 `Post('auth/2fa/setup/url')` API를 추가하였습니다.
   - 이 함수는 다음과 같은 형식으로 OTP 인증 URL을 반환합니다:
     ```json
     {
         "otpauthurl": "otpauth://totp/ft_transendence:user2%40example.com?secret=I5BE...BLJAU6UJTJ4======&period=30&digits=6&algorithm=SHA1&issuer=ft_transendence"
     }
     ```